### PR TITLE
Fix gcloud docker push

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,4 @@ docker build -t guestbook  .
 
 docker tag guestbook "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
 
-gcloud docker push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
+gcloud docker -- push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"


### PR DESCRIPTION
The gcloud docker push command fails unless -- is specified:
```
ERROR: gcloud crashed (ArgumentError): argument DOCKER_ARGS: unrecognized args: push eu.gcr.io/build-lgp/guestbook
The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right.

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
Build step 'Execute shell' marked build as failure
Finished: FAILURE
```