### PR TITLE
Update gcloud docker command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,4 @@ docker build -t guestbook  .
 
 docker tag guestbook "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
 
-gcloud docker push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
+gcloud docker -- push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"


### PR DESCRIPTION
Use new syntax to avoid this error: 
ERROR: (gcloud.docker) unrecognized arguments:
  push
  us.gcr.io/build-170623/guestbook